### PR TITLE
Different port numbers makes different hosts

### DIFF
--- a/lib/gollum.ex
+++ b/lib/gollum.ex
@@ -46,7 +46,7 @@ defmodule Gollum do
     name = opts[:name] || Gollum.Cache
 
     uri = URI.parse(url)
-    host = "#{uri.scheme}://#{uri.host}"
+    host = "#{uri.scheme}://#{uri.authority}"
     path = uri.path || "/"
 
     case Cache.fetch(host, name: name) do

--- a/test/gollum_test.exs
+++ b/test/gollum_test.exs
@@ -1,4 +1,15 @@
 defmodule GollumTest do
   use ExUnit.Case
+  alias Gollum.Cache
   doctest Gollum
+
+  setup do
+    Cache.start_link(name: TestCache, fetcher: MockFetcher)
+    :ok
+  end
+
+  test "uses port to diffentiate hosts" do
+    # Uses a fake response from MockFetcher
+    assert Gollum.crawlable?("Hello", "http://example.net:8080/some_path", name: TestCache) == :uncrawlable
+  end
 end

--- a/test/support/mock_fetcher.ex
+++ b/test/support/mock_fetcher.ex
@@ -12,4 +12,7 @@ defmodule MockFetcher do
   def fetch("http://example.com", _opts) do
     {:ok, "User-agent: Hello\nAllow: /hello\nDisallow: /hey"}
   end
+  def fetch("http://example.net:8080", _opts) do
+    {:ok, "User-agent: Hello\nDisallow: /some_path"}
+  end
 end


### PR DESCRIPTION
Hello and thank you for enhancing this library. Please consider this enhancement.

In think port number should be used to differentiate hosts, as described in https://developers.google.com/search/reference/robots_txt. For example http://example.com/ should not be considered the same host as http://example.com:8181/. This PR addresses this issue.